### PR TITLE
Add missing installation step for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ These are required for the project, and usually can be downloaded via your distr
 
 ```sh
 sudo apt install libsfml-dev libglm-dev
+sudo apt install build-essential cmake
 ```
 
 If not, then you can download them from the website:
@@ -53,6 +54,7 @@ If not, then you can download them from the website:
 
 [GLM Download](https://github.com/g-truc/glm/tags)
 
+[CMake](https://cmake.org/download)
 #### Building
 
 First clone the project and `cd`:


### PR DESCRIPTION
I use Linux Ubuntu and I couldn't build this game.
I found out that you need to install cmake first to run `sh scripts/build.sh`.