### PR TITLE
Added eof check in the server command execution loop.

### DIFF
--- a/src/server/server_engine.cpp
+++ b/src/server/server_engine.cpp
@@ -22,7 +22,8 @@ void runServerEngine(const ServerConfig &config, sf::Time timeout)
         while (serverRunning) {
             std::cout << "> ";
             std::getline(std::cin, line);
-            if (line == "exit") {
+
+            if (std::cin.eof() || line == "exit") {
                 serverRunning = false;
                 serverConsoleRunning = false;
                 return;


### PR DESCRIPTION
This is a fix for the 'Ctrl-D in server console'(#22) issue.