### PR TITLE
fix for handle mouse input

### DIFF
--- a/src/client/gameplay.cpp
+++ b/src/client/gameplay.cpp
@@ -117,7 +117,7 @@ void Gameplay::handleInput(const sf::Window &window, const Keyboard &keyboard)
     static auto lastMousepositionition = sf::Mouse::getPosition(window);
 
     // Handle mouse input
-    if (!m_isMouseLocked && window.hasFocus()) {
+    if (!m_isMouseLocked && window.hasFocus() && sf::Mouse::getPosition(window).y >= 0) {
         auto change = sf::Mouse::getPosition(window) - lastMousepositionition;
         mp_player->rotation.x += static_cast<float>(change.y / 8.0f);
         mp_player->rotation.y += static_cast<float>(change.x / 8.0f);


### PR DESCRIPTION
Fixed an issue where if the window is brought into focus using the top window border, the window is dragged down (moving the mouse itself, mouse drags window). Only the top border is selectable so this test should be enough