### PR TITLE
Add GitHub actions CI and unit testing

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,6 +13,6 @@ jobs:
       steps:
         - uses: actions/checkout@master
         - run: |
-            sudo apt install cmake libsfml-dev libglm-dev
+            sudo apt update && sudo apt install cmake libsfml-dev libglm-dev
             sh scripts/build.sh
             sh scripts/tests.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,18 @@
+name: C++ CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ ubuntu-18.04, ubuntu-latest ]
+          compiler: [ g++, clang++ ]
+      name: ${{ matrix.compiler }} on ${{ matrix.os }}
+      steps:
+        - uses: actions/checkout@master
+        - run: |
+            sudo apt install cmake libsfml-dev libglm-dev
+            sh scripts/build.sh
+            sh scripts/tests.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Open Builder 
 
+[![C++ CI](https://github.com/Hopson97/open-builder/workflows/C++%20CI/badge.svg)](https://github.com/Hopson97/open-builder/actions?query=workflow%3A"C%2B%2B+CI")
+
 Open source Minecraft-like voxel sandbox game with multiplayer support.
 
 More information about the project can be fouund in the **[Open Builder Wiki](https://github.com/Hopson97/open-builder/wiki)**


### PR DESCRIPTION
This adds GitHubs continuous integrations services to the repo. These can be used for indicating to a user that this project is maintained and functional. 