### PR TITLE
Update GitHub actions to use newly created installation routine (aka. new install script)

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,5 +13,5 @@ jobs:
       steps:
         - uses: actions/checkout@master
         - run: |
-            sh scripts/install.sh
+            sudo sh scripts/install.sh
             sh scripts/tests.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,6 +13,5 @@ jobs:
       steps:
         - uses: actions/checkout@master
         - run: |
-            sudo apt update && sudo apt install cmake libsfml-dev libglm-dev
-            sh scripts/build.sh
+            sh scripts/install.sh
             sh scripts/tests.sh

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,5 +13,5 @@ jobs:
       steps:
         - uses: actions/checkout@master
         - run: |
-            sudo sh scripts/install.sh
+            sudo bash scripts/install.sh
             sh scripts/tests.sh

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Please use the links below:
 We offer an automated installer for a bunch of different Linux distributions including Debian, Arch/Manjaro and Fedora. It can be ran via
 
 ```sh
-sudo sh scripts/install.sh
+sudo bash scripts/install.sh
 ```
 
 from the project root directory. If you are interested in the manual way of installation, check below instructions. To then finally run the application see [Running](https://github.com/Hopson97/open-builder#running) below.


### PR DESCRIPTION
Utilize the new installer in GitHub actions to get notifications if it is broken with Debian.