### PR TITLE
Refactor/enet peer refactor

### DIFF
--- a/src/client/client_engine.cpp
+++ b/src/client/client_engine.cpp
@@ -48,7 +48,7 @@ EngineStatus runClientEngine(const ClientConfig &config)
     glCheck(glEnable(GL_CULL_FACE));
     glCheck(glCullFace(GL_BACK));
 
-    //glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    // glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
     Gameplay gameplay;
     Keyboard keyboard;

--- a/src/client/client_state.h
+++ b/src/client/client_state.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <array>
-#include "maths.h"
-#include <common/world/chunk.h>
 #include "engine_status.h"
+#include "maths.h"
+#include <array>
+#include <common/world/chunk.h>
 
 struct Entity final {
     glm::vec3 position{0.0f, 0.0f, 12.0f}, rotation{0.0f};

--- a/src/client/gameplay.cpp
+++ b/src/client/gameplay.cpp
@@ -117,7 +117,8 @@ void Gameplay::handleInput(const sf::Window &window, const Keyboard &keyboard)
     static auto lastMousepositionition = sf::Mouse::getPosition(window);
 
     // Handle mouse input
-    if (!m_isMouseLocked && window.hasFocus() && sf::Mouse::getPosition(window).y >= 0) {
+    if (!m_isMouseLocked && window.hasFocus() &&
+        sf::Mouse::getPosition(window).y >= 0) {
         auto change = sf::Mouse::getPosition(window) - lastMousepositionition;
         mp_player->rotation.x += static_cast<float>(change.y / 8.0f);
         mp_player->rotation.y += static_cast<float>(change.x / 8.0f);
@@ -185,7 +186,8 @@ void Gameplay::update()
     auto &chunkMgr = m_clientState.chunkManager;
     for (auto itr = chunks.begin(); itr != chunks.end();) {
         const auto &[position, chunk] = *itr;
-        if (m_chunkRenders.find(position) == m_chunkRenders.end() && chunkMgr.hasNeighbours(position)) {
+        if (m_chunkRenders.find(position) == m_chunkRenders.end() &&
+            chunkMgr.hasNeighbours(position)) {
             m_chunkRenders.emplace(position, makeChunkMesh(*chunk));
             itr = chunks.erase(itr);
         }

--- a/src/client/gameplay.h
+++ b/src/client/gameplay.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include "client_engine.h"
+#include "client_state.h"
 #include "gl/gl_object.h"
 #include "maths.h"
+#include "network/client.h"
 #include <SFML/Network/Packet.hpp>
 #include <SFML/Window/Keyboard.hpp>
 #include <SFML/Window/Window.hpp>
 #include <common/network/enet.h>
 #include <common/network/net_types.h>
-#include "client_state.h"
-#include "network/client.h"
 #include <common/world/chunk.h>
 
 class Keyboard;
@@ -48,7 +48,7 @@ class Gameplay final {
 
     ClientState m_clientState;
     Client m_netClient;
-    
+
     Entity *mp_player = nullptr;
 
     ChunkPositionMap<gl::VertexArray> m_chunkRenders;

--- a/src/client/network/client.cpp
+++ b/src/client/network/client.cpp
@@ -2,14 +2,13 @@
 
 #include "../client_state.h"
 
-#include <thread>
 #include <common/debug.h>
+#include <thread>
 
 Client::Client(ClientState &state)
     : NetworkHost("Client")
     , mp_clientState(&state)
 {
-
 }
 
 std::optional<peer_id_t> Client::connectTo(const std::string &ipAddress)
@@ -39,8 +38,7 @@ void Client::sendPlayerPosition(const glm::vec3 &position)
 {
     sf::Packet packet;
     packet << ServerCommand::PlayerPosition << NetworkHost::getPeerId()
-           << position.x << position.y
-           << position.z;
+           << position.x << position.y << position.z;
     NetworkHost::sendToPeer(mp_serverPeer, packet, 0, 0);
 }
 
@@ -67,7 +65,8 @@ void Client::onPeerTimeout(ENetPeer *peer)
     mp_clientState->status = EngineStatus::ExitServerTimeout;
 }
 
-void Client::onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command)
+void Client::onCommandRecieve(ENetPeer *peer, sf::Packet &packet,
+                              command_t command)
 {
     switch (static_cast<ClientCommand>(command)) {
         case ClientCommand::PlayerJoin:
@@ -138,4 +137,3 @@ void Client::onChunkData(sf::Packet &packet)
     chunk.blocks = std::move(blocks);
     mp_clientState->chunks.emplace(position, &chunk);
 }
-

--- a/src/client/network/client.cpp
+++ b/src/client/network/client.cpp
@@ -26,12 +26,12 @@ void Client::sendDisconnectRequest()
 {
     sf::Packet packet;
     packet << ServerCommand::Disconnect << NetworkHost::getPeerId();
-    if (!sendToPeer(*mp_serverPeer, packet, 0, ENET_PACKET_FLAG_RELIABLE)) {
+    if (!sendToPeer(mp_serverPeer, packet, 0, ENET_PACKET_FLAG_RELIABLE)) {
         LOG("Client", "Failed to send disconnect packet");
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(64));
 
-    NetworkHost::disconnectFromPeer(*mp_serverPeer);
+    NetworkHost::disconnectFromPeer(mp_serverPeer);
     NetworkHost::destroy();
 }
 
@@ -41,7 +41,7 @@ void Client::sendPlayerPosition(const glm::vec3 &position)
     packet << ServerCommand::PlayerPosition << NetworkHost::getPeerId()
            << position.x << position.y
            << position.z;
-    NetworkHost::sendToPeer(*mp_serverPeer, packet, 0, 0);
+    NetworkHost::sendToPeer(mp_serverPeer, packet, 0, 0);
 }
 
 void Client::sendChunkRequest(const ChunkPosition &position)
@@ -49,20 +49,20 @@ void Client::sendChunkRequest(const ChunkPosition &position)
     sf::Packet packet;
     packet << ServerCommand::ChunkRequest << NetworkHost::getPeerId()
            << position.x << position.y << position.z;
-    NetworkHost::sendToPeer(*mp_serverPeer, packet, 0,
+    NetworkHost::sendToPeer(mp_serverPeer, packet, 0,
                             ENET_PACKET_FLAG_RELIABLE);
 }
 
-void Client::onPeerConnect(ENetPeer &peer)
+void Client::onPeerConnect(ENetPeer *peer)
 {
 }
 
-void Client::onPeerDisconnect(ENetPeer &peer)
+void Client::onPeerDisconnect(ENetPeer *peer)
 {
     mp_clientState->status = EngineStatus::ExitServerDisconnect;
 }
 
-void Client::onPeerTimeout(ENetPeer &peer)
+void Client::onPeerTimeout(ENetPeer *peer)
 {
     mp_clientState->status = EngineStatus::ExitServerTimeout;
 }

--- a/src/client/network/client.cpp
+++ b/src/client/network/client.cpp
@@ -67,7 +67,7 @@ void Client::onPeerTimeout(ENetPeer &peer)
     mp_clientState->status = EngineStatus::ExitServerTimeout;
 }
 
-void Client::onCommandRecieve(sf::Packet &packet, command_t command)
+void Client::onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command)
 {
     switch (static_cast<ClientCommand>(command)) {
         case ClientCommand::PlayerJoin:

--- a/src/client/network/client.h
+++ b/src/client/network/client.h
@@ -1,27 +1,27 @@
 #pragma once
 
+#include "../maths.h"
 #include <common/network/net_host.h>
 #include <common/world/chunk.h>
-#include "../maths.h"
 
 struct ClientState;
 
-
 class Client : public NetworkHost {
   public:
-    Client(ClientState& state);
+    Client(ClientState &state);
 
     std::optional<peer_id_t> connectTo(const std::string &ipAddress);
 
     void sendDisconnectRequest();
     void sendPlayerPosition(const glm::vec3 &position);
-    void sendChunkRequest(const ChunkPosition& position);
+    void sendChunkRequest(const ChunkPosition &position);
 
   private:
     void onPeerConnect(ENetPeer *peer) override;
     void onPeerDisconnect(ENetPeer *peer) override;
     void onPeerTimeout(ENetPeer *peer) override;
-    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
+    void onCommandRecieve(ENetPeer *peer, sf::Packet &packet,
+                          command_t command) override;
 
     void onPlayerJoin(sf::Packet &packet);
     void onPlayerLeave(sf::Packet &packet);

--- a/src/client/network/client.h
+++ b/src/client/network/client.h
@@ -18,9 +18,9 @@ class Client : public NetworkHost {
     void sendChunkRequest(const ChunkPosition& position);
 
   private:
-    void onPeerConnect(ENetPeer &peer) override;
-    void onPeerDisconnect(ENetPeer &peer) override;
-    void onPeerTimeout(ENetPeer &peer) override;
+    void onPeerConnect(ENetPeer *peer) override;
+    void onPeerDisconnect(ENetPeer *peer) override;
+    void onPeerTimeout(ENetPeer *peer) override;
     void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
 
     void onPlayerJoin(sf::Packet &packet);

--- a/src/client/network/client.h
+++ b/src/client/network/client.h
@@ -21,7 +21,7 @@ class Client : public NetworkHost {
     void onPeerConnect(ENetPeer &peer) override;
     void onPeerDisconnect(ENetPeer &peer) override;
     void onPeerTimeout(ENetPeer &peer) override;
-    void onCommandRecieve(sf::Packet &packet, command_t command) override;
+    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
 
     void onPlayerJoin(sf::Packet &packet);
     void onPlayerLeave(sf::Packet &packet);

--- a/src/client/window.h
+++ b/src/client/window.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "input/keyboard.h"
 #include "client_engine.h"
+#include "input/keyboard.h"
 #include <SFML/Window/Window.hpp>
 #include <common/types.h>
 

--- a/src/common/common/network/net_host.cpp
+++ b/src/common/common/network/net_host.cpp
@@ -61,10 +61,9 @@ int getPeerIdFromServer(ENetHost *host)
     return id;
 }
 
-ENetPacket* createPacket(sf::Packet &packet, u32 flags)
+ENetPacket *createPacket(sf::Packet &packet, u32 flags)
 {
-    return enet_packet_create(packet.getData(), packet.getDataSize(),
-                                         flags);
+    return enet_packet_create(packet.getData(), packet.getDataSize(), flags);
 }
 } // namespace
 
@@ -218,7 +217,7 @@ void NetworkHost::tick()
     }
 }
 
-void NetworkHost::onCommandRecieve(ENetPeer* peer, const ENetPacket &enetPacket)
+void NetworkHost::onCommandRecieve(ENetPeer *peer, const ENetPacket &enetPacket)
 {
     sf::Packet packet;
     packet.append(enetPacket.data, enetPacket.dataLength);

--- a/src/common/common/network/net_host.cpp
+++ b/src/common/common/network/net_host.cpp
@@ -107,9 +107,9 @@ bool NetworkHost::createAsServer(int maxConnections)
     return mp_host;
 }
 
-void NetworkHost::disconnectFromPeer(ENetPeer &peer)
+void NetworkHost::disconnectFromPeer(ENetPeer *peer)
 {
-    enet_peer_disconnect(&peer, static_cast<u32>(m_peerId));
+    enet_peer_disconnect(peer, static_cast<u32>(m_peerId));
     ENetEvent event;
     while (enet_host_service(mp_host, &event, 3000) > 0) {
         switch (event.type) {
@@ -125,7 +125,7 @@ void NetworkHost::disconnectFromPeer(ENetPeer &peer)
                 break;
         }
     }
-    enet_peer_reset(&peer);
+    enet_peer_reset(peer);
 }
 
 void NetworkHost::disconnectAllPeers()
@@ -169,11 +169,11 @@ int NetworkHost::getMaxConnections() const
     return m_maxConnections;
 }
 
-bool NetworkHost::sendToPeer(ENetPeer &peer, sf::Packet &packet, u8 channel,
+bool NetworkHost::sendToPeer(ENetPeer *peer, sf::Packet &packet, u8 channel,
                              u32 flags)
 {
     ENetPacket *pkt = createPacket(packet, flags);
-    int result = enet_peer_send(&peer, channel, pkt);
+    int result = enet_peer_send(peer, channel, pkt);
     flush();
     return result == 0;
 }
@@ -196,7 +196,7 @@ void NetworkHost::tick()
     while (enet_host_service(mp_host, &event, 0) > 0) {
         switch (event.type) {
             case ENET_EVENT_TYPE_CONNECT:
-                onPeerConnect(*event.peer);
+                onPeerConnect(event.peer);
                 break;
 
             case ENET_EVENT_TYPE_RECEIVE:
@@ -205,11 +205,11 @@ void NetworkHost::tick()
                 break;
 
             case ENET_EVENT_TYPE_DISCONNECT:
-                onPeerDisconnect(*event.peer);
+                onPeerDisconnect(event.peer);
                 break;
 
             case ENET_EVENT_TYPE_DISCONNECT_TIMEOUT:
-                onPeerTimeout(*event.peer);
+                onPeerTimeout(event.peer);
                 break;
 
             case ENET_EVENT_TYPE_NONE:

--- a/src/common/common/network/net_host.cpp
+++ b/src/common/common/network/net_host.cpp
@@ -200,7 +200,7 @@ void NetworkHost::tick()
                 break;
 
             case ENET_EVENT_TYPE_RECEIVE:
-                onCommandRecieve(*event.packet);
+                onCommandRecieve(event.peer, *event.packet);
                 enet_packet_destroy(event.packet);
                 break;
 
@@ -218,13 +218,13 @@ void NetworkHost::tick()
     }
 }
 
-void NetworkHost::onCommandRecieve(const ENetPacket &enetPacket)
+void NetworkHost::onCommandRecieve(ENetPeer* peer, const ENetPacket &enetPacket)
 {
     sf::Packet packet;
     packet.append(enetPacket.data, enetPacket.dataLength);
     command_t command;
     packet >> command;
-    onCommandRecieve(packet, command);
+    onCommandRecieve(peer, packet, command);
 }
 
 void NetworkHost::flush()

--- a/src/common/common/network/net_host.h
+++ b/src/common/common/network/net_host.h
@@ -50,7 +50,7 @@ class NetworkHost {
      *
      * @param peer The peer to disconnect from
      */
-    void disconnectFromPeer(ENetPeer &peer);
+    void disconnectFromPeer(ENetPeer *peer);
 
     /**
      * @brief Disconnects all peers from this host
@@ -72,7 +72,7 @@ class NetworkHost {
      * @return true The packet was sent successfully
      * @return false The packet was not sent
      */
-    bool sendToPeer(ENetPeer &peer, sf::Packet &packet, u8 channel, u32 flags);
+    bool sendToPeer(ENetPeer *peer, sf::Packet &packet, u8 channel, u32 flags);
 
     /**
      * @brief Broadcasts a packet to all connected peers
@@ -84,9 +84,9 @@ class NetworkHost {
     void broadcastToPeers(sf::Packet &packet, u8 channel, u32 flags);
 
   private:
-    virtual void onPeerConnect(ENetPeer &peer) = 0;
-    virtual void onPeerDisconnect(ENetPeer &peer) = 0;
-    virtual void onPeerTimeout(ENetPeer &peer) = 0;
+    virtual void onPeerConnect(ENetPeer *peer) = 0;
+    virtual void onPeerDisconnect(ENetPeer *peer) = 0;
+    virtual void onPeerTimeout(ENetPeer *peer) = 0;
     virtual void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) = 0;
 
     void onCommandRecieve(ENetPeer* peer, const ENetPacket &packet);

--- a/src/common/common/network/net_host.h
+++ b/src/common/common/network/net_host.h
@@ -87,9 +87,10 @@ class NetworkHost {
     virtual void onPeerConnect(ENetPeer *peer) = 0;
     virtual void onPeerDisconnect(ENetPeer *peer) = 0;
     virtual void onPeerTimeout(ENetPeer *peer) = 0;
-    virtual void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) = 0;
+    virtual void onCommandRecieve(ENetPeer *peer, sf::Packet &packet,
+                                  command_t command) = 0;
 
-    void onCommandRecieve(ENetPeer* peer, const ENetPacket &packet);
+    void onCommandRecieve(ENetPeer *peer, const ENetPacket &packet);
 
     void flush();
 

--- a/src/common/common/network/net_host.h
+++ b/src/common/common/network/net_host.h
@@ -87,9 +87,9 @@ class NetworkHost {
     virtual void onPeerConnect(ENetPeer &peer) = 0;
     virtual void onPeerDisconnect(ENetPeer &peer) = 0;
     virtual void onPeerTimeout(ENetPeer &peer) = 0;
-    virtual void onCommandRecieve(sf::Packet &packet, command_t command) = 0;
+    virtual void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) = 0;
 
-    void onCommandRecieve(const ENetPacket &packet);
+    void onCommandRecieve(ENetPeer* peer, const ENetPacket &packet);
 
     void flush();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,16 +14,14 @@
 
 #include <common/network/enet.h>
 
-
-//Enable nvidia
+// Enable nvidia
 #ifdef _WIN32
-        #define WIN32_LEAN_AND_MEAN
-        #include <Windows.h>
-        extern "C" {
-                _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
-        }
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+extern "C" {
+_declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+}
 #endif
-
 
 namespace {
 enum class LaunchType {

--- a/src/server/network/server.cpp
+++ b/src/server/network/server.cpp
@@ -43,10 +43,10 @@ void Server::sendChunk(peer_id_t peerId, const Chunk &chunk)
     if (!peer) {
         return;
     }
-    sendToPeer(*peer, packet, 1, ENET_PACKET_FLAG_RELIABLE);
+    sendToPeer(peer, packet, 1, ENET_PACKET_FLAG_RELIABLE);
 }
 
-void Server::onPeerConnect(ENetPeer &peer)
+void Server::onPeerConnect(ENetPeer *peer)
 {
     int slot = emptySlot();
     if (slot >= 0) {
@@ -63,18 +63,18 @@ void Server::onPeerConnect(ENetPeer &peer)
         broadcastToPeers(announcement, 0,
                          ENET_PACKET_FLAG_RELIABLE);
 
-        addPeer(&peer, id);
+        addPeer(peer, id);
     }
 }
 
-void Server::onPeerDisconnect(ENetPeer &peer)
+void Server::onPeerDisconnect(ENetPeer *peer)
 {
-    removePeer(peer.connectID);
+    removePeer(peer->connectID);
 }
 
-void Server::onPeerTimeout(ENetPeer &peer)
+void Server::onPeerTimeout(ENetPeer *peer)
 {
-    removePeer(peer.connectID);
+    removePeer(peer->connectID);
 }
 
 void Server::onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command)

--- a/src/server/network/server.cpp
+++ b/src/server/network/server.cpp
@@ -77,7 +77,7 @@ void Server::onPeerTimeout(ENetPeer &peer)
     removePeer(peer.connectID);
 }
 
-void Server::onCommandRecieve(sf::Packet &packet, command_t command)
+void Server::onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command)
 {
     switch (static_cast<ServerCommand>(command)) {
         case ServerCommand::PlayerPosition:

--- a/src/server/network/server.cpp
+++ b/src/server/network/server.cpp
@@ -10,7 +10,7 @@
 Server::Server()
     : NetworkHost("Server")
 {
-    //Create "spawn"
+    // Create "spawn"
     m_spawn = &m_chunkManager.addChunk({0, 0, 0});
     makeFlatTerrain(m_spawn);
 }
@@ -60,8 +60,7 @@ void Server::onPeerConnect(ENetPeer *peer)
         // Broadcast the connection event
         sf::Packet announcement;
         announcement << ClientCommand::PlayerJoin << id;
-        broadcastToPeers(announcement, 0,
-                         ENET_PACKET_FLAG_RELIABLE);
+        broadcastToPeers(announcement, 0, ENET_PACKET_FLAG_RELIABLE);
 
         addPeer(peer, id);
     }
@@ -77,7 +76,8 @@ void Server::onPeerTimeout(ENetPeer *peer)
     removePeer(peer->connectID);
 }
 
-void Server::onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command)
+void Server::onCommandRecieve(ENetPeer *peer, sf::Packet &packet,
+                              command_t command)
 {
     switch (static_cast<ServerCommand>(command)) {
         case ServerCommand::PlayerPosition:

--- a/src/server/network/server.h
+++ b/src/server/network/server.h
@@ -44,7 +44,8 @@ class Server final : public NetworkHost {
     void onPeerConnect(ENetPeer *peer) override;
     void onPeerDisconnect(ENetPeer *peer) override;
     void onPeerTimeout(ENetPeer *peer) override;
-    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
+    void onCommandRecieve(ENetPeer *peer, sf::Packet &packet,
+                          command_t command) override;
 
     void handleCommandDisconnect(sf::Packet &packet);
     void handleCommandPlayerPosition(sf::Packet &packet);

--- a/src/server/network/server.h
+++ b/src/server/network/server.h
@@ -44,7 +44,7 @@ class Server final : public NetworkHost {
     void onPeerConnect(ENetPeer &peer) override;
     void onPeerDisconnect(ENetPeer &peer) override;
     void onPeerTimeout(ENetPeer &peer) override;
-    void onCommandRecieve(sf::Packet &packet, command_t command) override;
+    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
 
     void handleCommandDisconnect(sf::Packet &packet);
     void handleCommandPlayerPosition(sf::Packet &packet);

--- a/src/server/network/server.h
+++ b/src/server/network/server.h
@@ -41,9 +41,9 @@ class Server final : public NetworkHost {
 
     void sendChunk(peer_id_t peerId, const Chunk &chunk);
 
-    void onPeerConnect(ENetPeer &peer) override;
-    void onPeerDisconnect(ENetPeer &peer) override;
-    void onPeerTimeout(ENetPeer &peer) override;
+    void onPeerConnect(ENetPeer *peer) override;
+    void onPeerDisconnect(ENetPeer *peer) override;
+    void onPeerTimeout(ENetPeer *peer) override;
     void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override;
 
     void handleCommandDisconnect(sf::Packet &packet);

--- a/tests/common/network/net_host_test.h
+++ b/tests/common/network/net_host_test.h
@@ -29,7 +29,7 @@ class TestServer : public NetworkHost {
     {
     }
 
-    void onCommandRecieve(sf::Packet &packet, command_t command) override
+    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override
     {
     }
 };
@@ -54,7 +54,7 @@ class TestClient : public NetworkHost {
     {
     }
 
-    void onCommandRecieve(sf::Packet &packet, command_t command) override
+    void onCommandRecieve(ENetPeer* peer, sf::Packet &packet, command_t command) override
     {
     }
 };

--- a/tests/common/network/net_host_test.h
+++ b/tests/common/network/net_host_test.h
@@ -13,7 +13,7 @@ class TestServer : public NetworkHost {
     }
 
   private:
-    void onPeerConnect(ENetPeer &peer) override
+    void onPeerConnect(ENetPeer *peer) override
     {
         sf::Packet packet;
         packet << ClientCommand::PeerId << static_cast<peer_id_t>(0);
@@ -21,11 +21,11 @@ class TestServer : public NetworkHost {
         sendToPeer(peer, packet, 0, ENET_PACKET_FLAG_RELIABLE);
     }
 
-    void onPeerDisconnect(ENetPeer &peer) override
+    void onPeerDisconnect(ENetPeer *peer) override
     {
     }
 
-    void onPeerTimeout(ENetPeer &peer) override
+    void onPeerTimeout(ENetPeer *peer) override
     {
     }
 
@@ -42,15 +42,15 @@ class TestClient : public NetworkHost {
     }
 
   private:
-    void onPeerConnect(ENetPeer &peer) override
+    void onPeerConnect(ENetPeer *peer) override
     {
     }
 
-    void onPeerDisconnect(ENetPeer &peer) override
+    void onPeerDisconnect(ENetPeer *peer) override
     {
     }
 
-    void onPeerTimeout(ENetPeer &peer) override
+    void onPeerTimeout(ENetPeer *peer) override
     {
     }
 
@@ -110,7 +110,7 @@ TEST_CASE("The client can interact with the server.")
 
         TestClient client;
         auto serverConnection = client.createAsClient(LOCAL_HOST);
-        client.disconnectFromPeer(**serverConnection);
+        client.disconnectFromPeer(*serverConnection);
 
         REQUIRE(server.getConnectedPeerCount() == 0);
         REQUIRE(client.getConnectedPeerCount() == 0);


### PR DESCRIPTION
just makes it so peers are pointers rather than references, as when passed to ENet functions (Which is really the only useof them) they have to pointers anyway.