### PR TITLE
Fix invalid Iterator after vector resize in for loop

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -244,7 +244,7 @@ void Client::update(float dt)
                     auto buffer = makeChunkMesh(chunk);
                     m_chunks.bufferables.push_back(buffer);
                     deleteChunkRenderable(*itr);
-                    m_chunks.updates.erase(itr);
+                    itr = m_chunks.updates.erase(itr);
 
                     // Break so that the game still runs while world is
                     // being built


### PR DESCRIPTION
The iterator in the for loop for chunk updates doesn't update after erase causing a debug assertion failure on VS2019 on debug mode x86.

