### PR TITLE
Pedantic Pull Request (promote simplex noise instead of perlin in issue template)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,4 +16,4 @@ assignees: ''
 
 ** Implementations ideas [optional]**
 
-[Eg, use perlin noise  to generate a smooth heightmap]
+[Eg, use simplex noise to generate a smooth heightmap]


### PR DESCRIPTION
Most cases where I see Perlin noise used, appear to be more because the user heard about it first, and not because it was best choice for the application. Attempting to help the cause in a small way, by changing the issue template to reference simplex noise instead of perlin noise. This way, impressionable new developers will be slightly less likely to hear about Perlin first, and be led down the same path.