### PR TITLE
Set CMAKE_CXX_STANDARD to C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-
+set(CMAKE_CXX_STANDARD 17)
 #Set up project
 project(open-builder 
     VERSION 1.0


### PR DESCRIPTION
Setting the `CMAKE_CXX_STANDARD` variable to `17` warns the CMake generators about which C++ standart to use for generated build systems,  as specified [here](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html)  and [here](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD).  

This will probably also help to fix some issues that [the wiki says Visual Studio has with CMake](https://github.com/Hopson97/open-builder/wiki/Building-(Visual-Studio)), **IF**, the MSVC version is later than 2015 Update 3.