### PR TITLE
Fixed Cmake + Windows builds in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ project(open-builder
     VERSION 1.0
 )
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+# Make the bin folder the "deploy" folder
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+endif()
+
 function (set_flags target)
     #Set C++17
     target_compile_features(${target} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ function (set_flags target)
         target_compile_options(${target} 
             PRIVATE 
             /W4 
-            /WX
         )
     else()
         target_compile_options(${target} 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "variables": []
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "-v",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/cmake_modules/FindSFML.cmake
+++ b/cmake_modules/FindSFML.cmake
@@ -17,6 +17,31 @@ find_path(SFML_INCLUDE_DIR SFML/Config.hpp
           PATH_SUFFIXES include
           PATHS ${FIND_SFML_PATHS})
 
+# Added to module, not in original
+# Used for shipping the game.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    find_path(SFML_BIN_DIR openal32.dll
+          PATH_SUFFIXES bin
+          PATHS ${FIND_SFML_PATHS})
+    if(SFML_BIN_DIR)
+        message(STATUS "Found binary release at ${SFML_BIN_DIR}")
+        # Now seperate all the release/debug dll's
+        foreach(FIND_SFML_COMPONENT ${SFML_FIND_COMPONENTS})
+            string(TOLOWER ${FIND_SFML_COMPONENT} FIND_SFML_COMPONENT_LOWER)
+            set(FIND_SFML_COMPONENT_NAME sfml-${FIND_SFML_COMPONENT_LOWER})
+            if(CMAKE_BUILD_TYPE MATCHES Debug)
+                # Set debug dll's'
+                list(APPEND SFML_BINARIES ${FIND_SFML_COMPONENT_NAME}-d-2.dll)
+            else()
+                # Set release dll's
+                list(APPEND SFML_BINARIES ${FIND_SFML_COMPONENT_NAME}-2.dll)
+            endif()
+        endforeach()
+    else()
+        message(SEND_ERROR "Could not find SFML dll's!")
+    endif()
+endif()
+
 set(SFML_VERSION_OK TRUE)
 if(SFML_FIND_VERSION AND SFML_INCLUDE_DIR)
     if("${SFML_INCLUDE_DIR}" MATCHES "SFML.framework")

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -32,3 +32,41 @@ target_include_directories(ob-client
 PRIVATE
 ${SFML_INCLUDE_DIR}
 )
+
+# Copy over the required files
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+# DLL's
+    foreach(BINARY ${SFML_BINARIES})
+        add_custom_command(TARGET ob-client POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+            ${SFML_BIN_DIR}/${BINARY}
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    endforeach()
+
+# Config file
+    if(NOT EXISTS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config.obd)
+        add_custom_command(TARGET ob-client POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_SOURCE_DIR}/config.obd
+                ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config.obd)
+    endif()
+
+# Scripts
+    add_custom_command(TARGET ob-client POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/game
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/game)
+
+# Shaders
+    add_custom_command(TARGET ob-client POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/shaders
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders)
+
+# Textures
+    add_custom_command(TARGET ob-client POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/texture_packs
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/texture_packs)
+
+endif()

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(ob-client
     ${SFML_DEPENDENCIES}
     ${CMAKE_DL_LIBS}
 )
+
+target_include_directories(ob-client
+PRIVATE
+${SFML_INCLUDE_DIR}
+)

--- a/src/common/common/CMakeLists.txt
+++ b/src/common/common/CMakeLists.txt
@@ -19,3 +19,8 @@ target_link_libraries(ob-common
     ${SFML_DEPENDENCIES}
     ${CMAKE_DL_LIBS}
 )
+
+target_include_directories(ob-common
+PUBLIC
+${SFML_INCLUDE_DIR}
+)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -18,3 +18,8 @@ target_link_libraries(ob-server
     ${SFML_DEPENDENCIES}
     ${CMAKE_DL_LIBS}
 )
+
+target_include_directories(ob-common
+PUBLIC
+${SFML_INCLUDE_DIR}
+)


### PR DESCRIPTION
First 2 commits fix open-build not compiling with Cmake + MSVC, third commit copies over all the required files (DLL's, LUA, textures, shaders) for windows builds.  Last commit just adds a release build for Visual Studio. Main problem with windows builds was that you forgot to add target_include_directories to your projects.

New guide would be something like:

1. Git Clone
2. Download & Extract SFML
3. Add SFML to your path environment variable (You may need to restart VS for this to take effect)
4. In the Visual Studio installer, makes sure you installed "Linux Development with C++", this will integrate Cmake into Visual Studio. You can check at Tools -> Get Tools and Features
5. Open the open-builder folder with Visual Studio
6. Click build

