### PR TITLE
Move chunk rendering to new function

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -38,6 +38,16 @@ void deleteChunkRenderable(const ChunkPosition &position,
         drawables.pop_back();
     }
 }
+
+void renderChunks(const std::vector<ChunkDrawable> &chunks,
+                  const ViewFrustum &frustum)
+{
+    for (const auto &chunk : chunks) {
+        if (frustum.chunkIsInFrustum(chunk.position)) {
+            chunk.vao.getDrawable().bindAndDraw();
+        }
+    }
+}
 } // namespace
 
 Client::Client()
@@ -380,24 +390,17 @@ void Client::render(int width, int height)
     m_chunkShader.program.bind();
     gl::loadUniform(m_chunkShader.projectionViewLocation, playerProjectionView);
 
-    for (const auto &chunk : m_chunks.drawables) {
-        if (m_frustum.chunkIsInFrustum(chunk.position)) {
-            chunk.vao.getDrawable().bindAndDraw();
-        }
-    }
+    renderChunks(m_chunks.drawables, m_frustum);
 
     // Render fluid mesh
+    glCheck(glEnable(GL_BLEND));
     m_fluidShader.program.bind();
     gl::loadUniform(m_fluidShader.timeLocation,
                     m_clock.getElapsedTime().asSeconds());
     gl::loadUniform(m_fluidShader.projectionViewLocation, playerProjectionView);
 
-    glCheck(glEnable(GL_BLEND));
-    for (const auto &chunk : m_chunks.fluidDrawables) {
-        if (m_frustum.chunkIsInFrustum(chunk.position)) {
-            chunk.vao.getDrawable().bindAndDraw();
-        }
-    }
+    renderChunks(m_chunks.fluidDrawables, m_frustum);
+
     glCheck(glDisable(GL_BLEND));
 
     // GUI


### PR DESCRIPTION
Moves the chunk rendering to a new function.

This is because fluid and solid chunks rendering had the exact same code, so I moved them apart to avoid this.