### PR TITLE
Reduce chunk mesh memory by packing tex coords from 36 bits to 11 bits

### DIFF
--- a/config.obd
+++ b/config.obd
@@ -15,5 +15,5 @@ CLIENT_DATA
 end
 
 SERVER_DATA
-    world_size 8
+    world_size 20
 end

--- a/config.obd
+++ b/config.obd
@@ -15,5 +15,5 @@ CLIENT_DATA
 end
 
 SERVER_DATA
-    world_size 20
+    world_size 8
 end

--- a/shaders/chunk/chunk_vertex.glsl
+++ b/shaders/chunk/chunk_vertex.glsl
@@ -1,7 +1,7 @@
 #version 330
 
 layout (location = 0) in uint inVertexCoord;
-layout (location = 1) in vec2 inTextureIndex;
+layout (location = 1) in uint inTextureIndex;
 layout (location = 2) in uint inTextureLayer;
 
 uniform vec3 chunkPosition;
@@ -10,6 +10,13 @@ uniform mat4 projectionViewMatrix;
 
 out vec3 passTexCoord;
 out float passBasicLight;
+
+vec2 texCoords[4] = vec2[4](
+    vec2(0.0f, 0.0f),
+    vec2(1.0f, 0.0f),
+    vec2(1.0f, 1.0f),
+    vec2(0.0f, 1.0f)
+);
 
 void main() {   
     float x = float(inVertexCoord & 0x3Fu);
@@ -20,6 +27,7 @@ void main() {
     z += chunkPosition.z;
     gl_Position = projectionViewMatrix * vec4(x, y, z, 1.0);
     
-    passTexCoord = vec3(inTextureIndex, float(inTextureLayer));
+    passTexCoord = vec3(texCoords[inTextureIndex], float(inTextureLayer));
     passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
 }
+    

--- a/shaders/chunk/chunk_vertex.glsl
+++ b/shaders/chunk/chunk_vertex.glsl
@@ -1,7 +1,8 @@
 #version 330
 
 layout (location = 0) in uint inVertexCoord;
-layout (location = 1) in vec3 inTextureCoord;
+layout (location = 1) in vec2 inTextureIndex;
+layout (location = 2) in uint inTextureLayer;
 
 uniform vec3 chunkPosition;
 
@@ -19,6 +20,6 @@ void main() {
     z += chunkPosition.z;
     gl_Position = projectionViewMatrix * vec4(x, y, z, 1.0);
     
-    passTexCoord = inTextureCoord;
+    passTexCoord = vec3(inTextureIndex, float(inTextureLayer));
     passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
 }

--- a/shaders/chunk/chunk_vertex.glsl
+++ b/shaders/chunk/chunk_vertex.glsl
@@ -1,6 +1,6 @@
 #version 330
 
-layout (location = 0) in uint inVertexCoord;
+layout (location = 0) in uint inVertexData;
 
 uniform vec3 chunkPosition;
 
@@ -17,19 +17,19 @@ vec2 texCoords[4] = vec2[4](
 );
 
 void main() {   
-    float x = float(inVertexCoord & 0x3Fu);
-    float y = float((inVertexCoord & 0xFC0u) >> 6u);
-    float z = float((inVertexCoord & 0x3F000u) >> 12u);
+    float x = float(inVertexData & 0x3Fu);
+    float y = float((inVertexData & 0xFC0u) >> 6u);
+    float z = float((inVertexData & 0x3F000u) >> 12u);
     x += chunkPosition.x;
     y += chunkPosition.y;
     z += chunkPosition.z;
     gl_Position = projectionViewMatrix * vec4(x, y, z, 1.0);
 
     //Texture coords
-    uint index = (inVertexCoord & 0x600000u) >> 21u;
-    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
+    uint index = (inVertexData & 0x600000u) >> 21u;
+    uint layer = (inVertexData & 0xFF800000u) >> 23u;
     
     passTexCoord = vec3(texCoords[index], float(layer));
-    passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
+    passBasicLight = float((inVertexData & 0x1C0000u) >> 18u) / 5.0f;
 }
     

--- a/shaders/chunk/chunk_vertex.glsl
+++ b/shaders/chunk/chunk_vertex.glsl
@@ -1,8 +1,6 @@
 #version 330
 
 layout (location = 0) in uint inVertexCoord;
-layout (location = 1) in uint inTextureIndex;
-layout (location = 2) in uint inTextureLayer;
 
 uniform vec3 chunkPosition;
 
@@ -26,8 +24,12 @@ void main() {
     y += chunkPosition.y;
     z += chunkPosition.z;
     gl_Position = projectionViewMatrix * vec4(x, y, z, 1.0);
+
+    //Texture coords
+    uint index = (inVertexCoord & 0x600000u) >> 21u;
+    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
     
-    passTexCoord = vec3(texCoords[inTextureIndex], float(inTextureLayer));
+    passTexCoord = vec3(texCoords[index], float(layer));
     passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
 }
     

--- a/shaders/chunk/flora_vertex.glsl
+++ b/shaders/chunk/flora_vertex.glsl
@@ -1,6 +1,6 @@
 #version 330
 
-layout (location = 0) in uint inVertexCoord;
+layout (location = 0) in uint inVertexData;
 
 uniform vec3 chunkPosition;
 
@@ -27,9 +27,9 @@ vec4 waveLeaf(vec3 position)
 }
 
 void main() {
-    float x = float(inVertexCoord & 0x3Fu);
-    float y = float((inVertexCoord & 0xFC0u) >> 6u);
-    float z = float((inVertexCoord & 0x3F000u) >> 12u);
+    float x = float(inVertexData & 0x3Fu);
+    float y = float((inVertexData & 0xFC0u) >> 6u);
+    float z = float((inVertexData & 0x3F000u) >> 12u);
     x += chunkPosition.x;
     y += chunkPosition.y;
     z += chunkPosition.z;
@@ -39,9 +39,9 @@ void main() {
     gl_Position = projectionViewMatrix * position;
     
     //Texture coords
-    uint index = (inVertexCoord & 0x600000u) >> 21u;
-    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
+    uint index = (inVertexData & 0x600000u) >> 21u;
+    uint layer = (inVertexData & 0xFF800000u) >> 23u;
     
     passTexCoord = vec3(texCoords[index], float(layer));
-    passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
+    passBasicLight = float((inVertexData & 0x1C0000u) >> 18u) / 5.0f;
 }

--- a/shaders/chunk/flora_vertex.glsl
+++ b/shaders/chunk/flora_vertex.glsl
@@ -1,7 +1,6 @@
 #version 330
 
 layout (location = 0) in uint inVertexCoord;
-layout (location = 1) in vec3 inTextureCoord;
 
 uniform vec3 chunkPosition;
 
@@ -10,6 +9,14 @@ uniform float time;
 
 out vec3 passTexCoord;
 out float passBasicLight;
+
+vec2 texCoords[4] = vec2[4](
+    vec2(0.0f, 0.0f),
+    vec2(1.0f, 0.0f),
+    vec2(1.0f, 1.0f),
+    vec2(0.0f, 1.0f)
+);
+
 
 vec4 waveLeaf(vec3 position)
 {
@@ -31,6 +38,10 @@ void main() {
 
     gl_Position = projectionViewMatrix * position;
     
-    passTexCoord = inTextureCoord;
+    //Texture coords
+    uint index = (inVertexCoord & 0x600000u) >> 21u;
+    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
+    
+    passTexCoord = vec3(texCoords[index], float(layer));
     passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
 }

--- a/shaders/chunk/water_vertex.glsl
+++ b/shaders/chunk/water_vertex.glsl
@@ -1,7 +1,6 @@
 #version 330
 
 layout (location = 0) in uint inVertexCoord;
-layout (location = 1) in vec3 inTextureCoord;
 
 uniform vec3 chunkPosition;
 
@@ -10,6 +9,14 @@ uniform float time;
 
 out vec3 passTexCoord;
 out float passBasicLight;
+
+vec2 texCoords[4] = vec2[4](
+    vec2(0.0f, 0.0f),
+    vec2(1.0f, 0.0f),
+    vec2(1.0f, 1.0f),
+    vec2(0.0f, 1.0f)
+);
+
 
 vec4 createWaveOffset(vec3 position)
 {
@@ -30,7 +37,11 @@ void main() {
     vec4 position = createWaveOffset(vec3(x, y, z));
 
     gl_Position = projectionViewMatrix * position;
+
+    //Texture coords
+    uint index = (inVertexCoord & 0x600000u) >> 21u;
+    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
     
-    passTexCoord = inTextureCoord;
+    passTexCoord = vec3(texCoords[index], float(layer));
     passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
 }

--- a/shaders/chunk/water_vertex.glsl
+++ b/shaders/chunk/water_vertex.glsl
@@ -1,6 +1,6 @@
 #version 330
 
-layout (location = 0) in uint inVertexCoord;
+layout (location = 0) in uint inVertexData;
 
 uniform vec3 chunkPosition;
 
@@ -27,9 +27,9 @@ vec4 createWaveOffset(vec3 position)
 }
 
 void main() {
-    float x = float(inVertexCoord & 0x3Fu);
-    float y = float((inVertexCoord & 0xFC0u) >> 6u);
-    float z = float((inVertexCoord & 0x3F000u) >> 12u);
+    float x = float(inVertexData & 0x3Fu);
+    float y = float((inVertexData & 0xFC0u) >> 6u);
+    float z = float((inVertexData & 0x3F000u) >> 12u);
     x += chunkPosition.x;
     y += chunkPosition.y;
     z += chunkPosition.z;
@@ -39,9 +39,9 @@ void main() {
     gl_Position = projectionViewMatrix * position;
 
     //Texture coords
-    uint index = (inVertexCoord & 0x600000u) >> 21u;
-    uint layer = (inVertexCoord & 0xFF800000u) >> 23u;
+    uint index = (inVertexData & 0x600000u) >> 21u;
+    uint layer = (inVertexData & 0xFF800000u) >> 23u;
     
     passTexCoord = vec3(texCoords[index], float(layer));
-    passBasicLight = float((inVertexCoord & 0x1C0000u) >> 18u) / 5.0f;
+    passBasicLight = float((inVertexData & 0x1C0000u) >> 18u) / 5.0f;
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -478,7 +478,7 @@ void Client::render(int width, int height)
         renderChunks(m_chunks.drawables, m_frustum, m_chunkShader.chunkPositionLocation, bytesRendered);
     
     // Render the flora blocks
-    /*
+   
     glDisable(GL_CULL_FACE);
     m_floraShader.program.bind();
     gl::loadUniform(m_floraShader.timeLocation, time);
@@ -486,7 +486,7 @@ void Client::render(int width, int height)
     renderChunks(m_chunks.floraDrawables, m_frustum, m_floraShader.chunkPositionLocation,
                  bytesRendered);
     glEnable(GL_CULL_FACE);
-    */
+    
     
 
     glCheck(glEnable(GL_BLEND));
@@ -508,7 +508,7 @@ void Client::render(int width, int height)
     }
 
     // Render fluid mesh
-    /*
+    
     m_fluidShader.program.bind();
     gl::loadUniform(m_fluidShader.timeLocation, time);
     gl::loadUniform(m_fluidShader.projectionViewLocation, playerProjectionView);
@@ -517,7 +517,7 @@ void Client::render(int width, int height)
     }
     renderChunks(m_chunks.fluidDrawables, m_frustum, m_fluidShader.chunkPositionLocation,
                  bytesRendered);
-                 */
+                 
     
     glCheck(glDisable(GL_BLEND));
     glCheck(glCullFace(GL_BACK));

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -478,6 +478,7 @@ void Client::render(int width, int height)
         renderChunks(m_chunks.drawables, m_frustum, m_chunkShader.chunkPositionLocation, bytesRendered);
     
     // Render the flora blocks
+    /*
     glDisable(GL_CULL_FACE);
     m_floraShader.program.bind();
     gl::loadUniform(m_floraShader.timeLocation, time);
@@ -485,6 +486,7 @@ void Client::render(int width, int height)
     renderChunks(m_chunks.floraDrawables, m_frustum, m_floraShader.chunkPositionLocation,
                  bytesRendered);
     glEnable(GL_CULL_FACE);
+    */
     
 
     glCheck(glEnable(GL_BLEND));
@@ -506,7 +508,7 @@ void Client::render(int width, int height)
     }
 
     // Render fluid mesh
-    
+    /*
     m_fluidShader.program.bind();
     gl::loadUniform(m_fluidShader.timeLocation, time);
     gl::loadUniform(m_fluidShader.projectionViewLocation, playerProjectionView);
@@ -515,6 +517,7 @@ void Client::render(int width, int height)
     }
     renderChunks(m_chunks.fluidDrawables, m_frustum, m_fluidShader.chunkPositionLocation,
                  bytesRendered);
+                 */
     
     glCheck(glDisable(GL_BLEND));
     glCheck(glCullFace(GL_BACK));

--- a/src/client/world/chunk_mesh.cpp
+++ b/src/client/world/chunk_mesh.cpp
@@ -31,8 +31,8 @@ void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition
 
         vertexAndLight.push_back(vertex);
     }
-    textureCoords.insert(textureCoords.end(),
-                         {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f});
+    textureCoordIndex.insert(textureCoordIndex.end(), {0, 1, 2, 3});
+                        
     textureLayer.insert(textureLayer.end(), {texture, texture, texture, texture});
 
         /*
@@ -54,7 +54,7 @@ gl::VertexArray ChunkMesh::createBuffer()
     gl::VertexArray vao;
     vao.bind();
     vao.addVertexBuffer(1, vertexAndLight);
-    vao.addVertexBuffer(2, textureCoords);
+    vao.addVertexBuffer(1, textureCoordIndex);
     vao.addVertexBuffer(1, textureLayer);
     // vao.addVertexBuffer(3, textureCoords);
     vao.addIndexBuffer(indices);

--- a/src/client/world/chunk_mesh.cpp
+++ b/src/client/world/chunk_mesh.cpp
@@ -14,12 +14,12 @@ ChunkMesh::ChunkMesh(const ChunkPosition& chunkPosition)
     : position(chunkPosition)
 {
     vertexAndLight.reserve(CHUNK_VOLUME);
-    textureCoords.reserve(CHUNK_VOLUME * 2);
+    // textureCoords.reserve(CHUNK_VOLUME * 2);
     indices.reserve(CHUNK_VOLUME * 2);
 }
 
 void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition,
-                        int texture)
+                        GLuint texture)
 {
     int index = 0;
     for (int i = 0; i < 4; i++) {
@@ -31,11 +31,15 @@ void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition
 
         vertexAndLight.push_back(vertex);
     }
-
     textureCoords.insert(textureCoords.end(),
-                         {0.0f, 0.0f, (float)texture, 1.0f, 0.0f, (float)texture, 1.0f,
-                          1.0f, (float)texture, 0.0f, 1.0f, (float)texture});
+                         {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f});
+    textureLayer.insert(textureLayer.end(), {texture, texture, texture, texture});
 
+        /*
+        textureCoords.insert(textureCoords.end(),
+                             {0.0f, 0.0f, (float)texture, 1.0f, 0.0f,
+        (float)texture, 1.0f, 1.0f, (float)texture, 0.0f, 1.0f, (float)texture});
+        */
     indices.push_back(indicesCount);
     indices.push_back(indicesCount + 1);
     indices.push_back(indicesCount + 2);
@@ -50,14 +54,17 @@ gl::VertexArray ChunkMesh::createBuffer()
     gl::VertexArray vao;
     vao.bind();
     vao.addVertexBuffer(1, vertexAndLight);
-    vao.addVertexBuffer(3, textureCoords);
+    vao.addVertexBuffer(2, textureCoords);
+    vao.addVertexBuffer(1, textureLayer);
+    // vao.addVertexBuffer(3, textureCoords);
     vao.addIndexBuffer(indices);
     return vao;
 }
 
 size_t ChunkMesh::calculateBufferSize() const
 {
-    return vecSize(vertexAndLight) + vecSize(textureCoords) + vecSize(indices);
+    return 0;
+    // return vecSize(vertexAndLight) + vecSize(textureCoords) + vecSize(indices);
 }
 
 ChunkMeshCollection::ChunkMeshCollection(const ChunkPosition& chunkPosition)

--- a/src/client/world/chunk_mesh.cpp
+++ b/src/client/world/chunk_mesh.cpp
@@ -22,24 +22,16 @@ void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition
                         GLuint texture)
 {
     int index = 0;
-    for (int i = 0; i < 4; i++) {
+    for (unsigned i = 0; i < 4; i++) {
         GLubyte x = face.vertices[index++] + blockPosition.x;
         GLubyte y = face.vertices[index++] + blockPosition.y;
         GLubyte z = face.vertices[index++] + blockPosition.z;
 
-        GLuint vertex = x | y << 6 | z << 12 | face.lightLevel << 18;
+        GLuint vertex =
+            x | y << 6 | z << 12 | face.lightLevel << 18 | i << 21 | texture << 23;
 
         vertexAndLight.push_back(vertex);
     }
-    textureCoordIndex.insert(textureCoordIndex.end(), {0, 1, 2, 3});
-                        
-    textureLayer.insert(textureLayer.end(), {texture, texture, texture, texture});
-
-        /*
-        textureCoords.insert(textureCoords.end(),
-                             {0.0f, 0.0f, (float)texture, 1.0f, 0.0f,
-        (float)texture, 1.0f, 1.0f, (float)texture, 0.0f, 1.0f, (float)texture});
-        */
     indices.push_back(indicesCount);
     indices.push_back(indicesCount + 1);
     indices.push_back(indicesCount + 2);
@@ -54,17 +46,13 @@ gl::VertexArray ChunkMesh::createBuffer()
     gl::VertexArray vao;
     vao.bind();
     vao.addVertexBuffer(1, vertexAndLight);
-    vao.addVertexBuffer(1, textureCoordIndex);
-    vao.addVertexBuffer(1, textureLayer);
-    // vao.addVertexBuffer(3, textureCoords);
     vao.addIndexBuffer(indices);
     return vao;
 }
 
 size_t ChunkMesh::calculateBufferSize() const
 {
-    return 0;
-    // return vecSize(vertexAndLight) + vecSize(textureCoords) + vecSize(indices);
+    return vecSize(vertexAndLight) + vecSize(indices);
 }
 
 ChunkMeshCollection::ChunkMeshCollection(const ChunkPosition& chunkPosition)

--- a/src/client/world/chunk_mesh.cpp
+++ b/src/client/world/chunk_mesh.cpp
@@ -1,7 +1,6 @@
 #include "chunk_mesh.h"
 
 #include <common/world/world_constants.h>
-
 namespace {
 template <typename T>
 size_t vecSize(const std::vector<T> vect)
@@ -13,8 +12,7 @@ size_t vecSize(const std::vector<T> vect)
 ChunkMesh::ChunkMesh(const ChunkPosition& chunkPosition)
     : position(chunkPosition)
 {
-    vertexAndLight.reserve(CHUNK_VOLUME);
-    // textureCoords.reserve(CHUNK_VOLUME * 2);
+    vertexData.reserve(CHUNK_VOLUME * 2);
     indices.reserve(CHUNK_VOLUME * 2);
 }
 
@@ -27,10 +25,12 @@ void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition
         GLubyte y = face.vertices[index++] + blockPosition.y;
         GLubyte z = face.vertices[index++] + blockPosition.z;
 
+        // Packs the vertex coordinates, cardinal light, and texture coordinates into 4
+        // bytes
         GLuint vertex =
             x | y << 6 | z << 12 | face.lightLevel << 18 | i << 21 | texture << 23;
 
-        vertexAndLight.push_back(vertex);
+        vertexData.push_back(vertex);
     }
     indices.push_back(indicesCount);
     indices.push_back(indicesCount + 1);
@@ -45,14 +45,14 @@ gl::VertexArray ChunkMesh::createBuffer()
 {
     gl::VertexArray vao;
     vao.bind();
-    vao.addVertexBuffer(1, vertexAndLight);
+    vao.addVertexBuffer(1, vertexData);
     vao.addIndexBuffer(indices);
     return vao;
 }
 
 size_t ChunkMesh::calculateBufferSize() const
 {
-    return vecSize(vertexAndLight) + vecSize(indices);
+    return vecSize(vertexData) + vecSize(indices);
 }
 
 ChunkMeshCollection::ChunkMeshCollection(const ChunkPosition& chunkPosition)

--- a/src/client/world/chunk_mesh.h
+++ b/src/client/world/chunk_mesh.h
@@ -18,7 +18,7 @@ struct ChunkMesh {
 
     size_t calculateBufferSize() const;
 
-    std::vector<GLuint> vertexAndLight;
+    std::vector<GLuint> vertexData;
     std::vector<GLuint> indices;
     int indicesCount = 0;
 

--- a/src/client/world/chunk_mesh.h
+++ b/src/client/world/chunk_mesh.h
@@ -19,7 +19,7 @@ struct ChunkMesh {
     size_t calculateBufferSize() const;
 
     std::vector<GLuint> vertexAndLight;
-    std::vector<GLfloat> textureCoords;
+    std::vector<GLuint> textureCoordIndex;
     std::vector<GLuint> textureLayer;
     //std::vector<GLfloat> textureCoords;
     std::vector<GLuint> indices;

--- a/src/client/world/chunk_mesh.h
+++ b/src/client/world/chunk_mesh.h
@@ -19,9 +19,6 @@ struct ChunkMesh {
     size_t calculateBufferSize() const;
 
     std::vector<GLuint> vertexAndLight;
-    std::vector<GLuint> textureCoordIndex;
-    std::vector<GLuint> textureLayer;
-    //std::vector<GLfloat> textureCoords;
     std::vector<GLuint> indices;
     int indicesCount = 0;
 

--- a/src/client/world/chunk_mesh.h
+++ b/src/client/world/chunk_mesh.h
@@ -11,7 +11,8 @@ struct MeshFace {
 
 struct ChunkMesh {
     ChunkMesh(const ChunkPosition& chunkPosition);
-    void addFace(const MeshFace& face, const BlockPosition& blockPosition, int texture);
+    void addFace(const MeshFace& face, const BlockPosition& blockPosition,
+                 GLuint texture);
 
     gl::VertexArray createBuffer();
 
@@ -19,6 +20,8 @@ struct ChunkMesh {
 
     std::vector<GLuint> vertexAndLight;
     std::vector<GLfloat> textureCoords;
+    std::vector<GLuint> textureLayer;
+    //std::vector<GLfloat> textureCoords;
     std::vector<GLuint> indices;
     int indicesCount = 0;
 


### PR DESCRIPTION
Puts the texture coordinates into the shader, passing 2 bits for an index and the remaining 9 bits for the "layer" of the texture atlas