### PR TITLE
Optimize/remove index buffer from chunks

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -372,7 +372,7 @@ void Client::render(int width, int height)
             translateMatrix(modelMatrix,
                             {ent.position.x, ent.position.y, ent.position.z});
             gl::loadUniform(m_basicShader.modelLocation, modelMatrix);
-            drawable.draw();
+            drawable.drawElements();
         }
     };
     // Render chunks
@@ -400,7 +400,7 @@ void Client::render(int width, int height)
         scaleMatrix(modelMatrix, size);
         gl::loadUniform(m_selectionShader.modelLocation, modelMatrix);
         gl::loadUniform(m_selectionShader.projectionViewLocation, playerProjectionView);
-        m_selectionBox.getDrawable().bindAndDraw(GL_LINES);
+        m_selectionBox.getDrawable().bindAndDrawElements(GL_LINES);
         glCheck(glDisable(GL_BLEND));
     }
 

--- a/src/client/gl/vertex_array.cpp
+++ b/src/client/gl/vertex_array.cpp
@@ -36,10 +36,16 @@ Drawable::Drawable(GLuint vao, GLsizei indices)
 {
 }
 
-void Drawable::bindAndDraw(GLenum drawMode) const
+void Drawable::bindAndDrawElements(GLenum drawMode) const
 {
     bind();
-    draw(drawMode);
+    drawElements(drawMode);
+}
+
+void Drawable::bindAndDrawArrays(GLenum drawMode) const
+{
+    bind();
+    drawArrays(drawMode);
 }
 
 void Drawable::bind() const
@@ -47,9 +53,14 @@ void Drawable::bind() const
     glCheck(glBindVertexArray(m_handle));
 }
 
-void Drawable::draw(GLenum drawMode) const
+void Drawable::drawElements(GLenum drawMode) const
 {
     glCheck(glDrawElements(drawMode, m_indicesCount, GL_UNSIGNED_INT, nullptr));
+}
+
+void Drawable::drawArrays(GLenum drawMode) const
+{
+    glCheck(glDrawArrays(drawMode, 0, m_indicesCount));
 }
 
 //
@@ -137,6 +148,11 @@ void VertexArray::addIndexBuffer(const std::vector<GLuint>& indices)
 
     m_bufferObjects.push_back(elementBuffer);
     m_indicesCount = indices.size();
+}
+
+void VertexArray::setIndicesCount(GLsizei count)
+{
+    m_indicesCount = count;
 }
 
 void VertexArray::reset()

--- a/src/client/gl/vertex_array.h
+++ b/src/client/gl/vertex_array.h
@@ -5,17 +5,19 @@
 
 namespace gl {
 /**
- * @brief Minimal information for drawing with glDrawElements
+ * @brief Minimal information for drawing with glDrawElements/ glDrawArrays
  *
  */
 class Drawable final {
   public:
     Drawable(GLuint vao, GLsizei indices);
 
-    void bindAndDraw(GLenum drawMode = GL_TRIANGLES) const;
+    void bindAndDrawElements(GLenum drawMode = GL_TRIANGLES) const;
+    void bindAndDrawArrays(GLenum drawMode = GL_TRIANGLES) const;
 
     void bind() const;
-    void draw(GLenum drawMode = GL_TRIANGLES) const;
+    void drawElements(GLenum drawMode = GL_TRIANGLES) const;
+    void drawArrays(GLenum drawMode = GL_TRIANGLES) const;
 
   private:
     const GLuint m_handle = 0;
@@ -45,6 +47,11 @@ class VertexArray final {
     void addVertexBuffer(int magnitude, const std::vector<GLuint>& data);
     void addVertexBuffer(int magnitude, const std::vector<GLfloat>& data);
     void addIndexBuffer(const std::vector<GLuint>& indices);
+
+    /**
+        This is for drawing with glDrawArrays
+    */
+    void setIndicesCount(GLsizei count);
 
   private:
     void reset();

--- a/src/client/gui/gui.cpp
+++ b/src/client/gui/gui.cpp
@@ -110,7 +110,7 @@ void Gui::render(float width, float height)
         gl::loadUniform(m_guiShader.modelLocation, modelMatrix);
         gl::loadUniform(m_guiShader.colorLocation, img.colour);
 
-        d.draw();
+        d.drawElements();
     }
 }
 

--- a/src/client/gui/text.cpp
+++ b/src/client/gui/text.cpp
@@ -167,7 +167,7 @@ void Text::render(const gl::UniformLocation& location)
 
     gl::loadUniform(location, modelMatrix);
 
-    m_vao.getDrawable().bindAndDraw();
+    m_vao.getDrawable().bindAndDrawElements();
     glCullFace(GL_BACK);
     glDisable(GL_BLEND);
 }

--- a/src/client/renderer/chunk_renderer.cpp
+++ b/src/client/renderer/chunk_renderer.cpp
@@ -57,7 +57,7 @@ void renderChunks(const ChunkRenderList& chunks, const ViewFrustum& frustum,
             cp *= CHUNK_SIZE;
             gl::loadUniform(chunkPositionLocation, cp);
 
-            chunk.vao.getDrawable().bindAndDraw();
+            chunk.vao.getDrawable().bindAndDrawArrays();
 
             outResult.chunksRendered++;
             outResult.bytesInView += chunk.bufferSize;
@@ -73,7 +73,7 @@ void renderChunks(const ChunkRenderList& chunks, const ViewFrustum& frustum,
  */
 void bufferChunks(ChunkMesh& mesh, ChunkRenderList& renderList)
 {
-    if (mesh.indicesCount > 0) {
+    if (mesh.vertexCount() > 0) {
         renderList.push_back(
             {mesh.position, mesh.createBuffer(), mesh.calculateBufferSize()});
     }

--- a/src/client/world/chunk_mesh.cpp
+++ b/src/client/world/chunk_mesh.cpp
@@ -13,13 +13,14 @@ ChunkMesh::ChunkMesh(const ChunkPosition& chunkPosition)
     : position(chunkPosition)
 {
     vertexData.reserve(CHUNK_VOLUME * 2);
-    indices.reserve(CHUNK_VOLUME * 2);
 }
 
 void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition,
                         GLuint texture)
 {
     int index = 0;
+    std::vector<GLuint> quad;
+    quad.reserve(4);
     for (unsigned i = 0; i < 4; i++) {
         GLubyte x = face.vertices[index++] + blockPosition.x;
         GLubyte y = face.vertices[index++] + blockPosition.y;
@@ -30,29 +31,33 @@ void ChunkMesh::addFace(const MeshFace& face, const BlockPosition& blockPosition
         GLuint vertex =
             x | y << 6 | z << 12 | face.lightLevel << 18 | i << 21 | texture << 23;
 
-        vertexData.push_back(vertex);
+        quad.push_back(vertex);
     }
-    indices.push_back(indicesCount);
-    indices.push_back(indicesCount + 1);
-    indices.push_back(indicesCount + 2);
-    indices.push_back(indicesCount + 2);
-    indices.push_back(indicesCount + 3);
-    indices.push_back(indicesCount);
-    indicesCount += 4;
+    vertexData.push_back(quad[0]);
+    vertexData.push_back(quad[1]);
+    vertexData.push_back(quad[2]);
+    vertexData.push_back(quad[2]);
+    vertexData.push_back(quad[3]);
+    vertexData.push_back(quad[0]);
 }
 
 gl::VertexArray ChunkMesh::createBuffer()
 {
     gl::VertexArray vao;
     vao.bind();
+    vao.setIndicesCount(vertexData.size());
     vao.addVertexBuffer(1, vertexData);
-    vao.addIndexBuffer(indices);
     return vao;
 }
 
 size_t ChunkMesh::calculateBufferSize() const
 {
-    return vecSize(vertexData) + vecSize(indices);
+    return vecSize(vertexData);
+}
+
+size_t ChunkMesh::vertexCount() const
+{
+    return vertexData.size();
 }
 
 ChunkMeshCollection::ChunkMeshCollection(const ChunkPosition& chunkPosition)

--- a/src/client/world/chunk_mesh.h
+++ b/src/client/world/chunk_mesh.h
@@ -18,9 +18,9 @@ struct ChunkMesh {
 
     size_t calculateBufferSize() const;
 
+    size_t vertexCount() const;
+
     std::vector<GLuint> vertexData;
-    std::vector<GLuint> indices;
-    int indicesCount = 0;
 
     ChunkPosition position;
 };


### PR DESCRIPTION
Removes the index buffer from chunk mesh

This is not needed since the vertex data is 4 bytes per vertex anyways, so this cuts down even more memory usage.

While testing, a 640x640 block world was reduced from 52mb of chunk vertex data to 32mb

A 1120x1120 block world was reudced from to 156mb of chunk vertex data 94MB 

However, seems to reduce performance so maybe not worth it? glDrawElements seems to be faster, but I'll make this PR anyways for educational purposes :S

(Large world, using elements was drawing the whole world at 70FPS, whereas the using drawArrays was at 46FPS)