### PR TITLE
[Client] Simplify the chunk updating code

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -131,7 +131,7 @@ class Client final : public NetworkHost {
 
     struct {
         ChunkManager manager;
-        std::vector<ChunkPosition> updates;
+        std::unordered_set<ChunkPosition, ChunkPositionHash> updates;
         std::vector<BlockUpdate> blockUpdates;
     } m_chunks;
 
@@ -153,7 +153,4 @@ class Client final : public NetworkHost {
     // Engine-y stuff
     EngineStatus m_status = EngineStatus::Ok;
     bool m_isMouseLocked = false;
-
-    unsigned m_noMeshingCount = 0;
-    bool m_blockMeshing = false;
 };

--- a/src/client/network/client_commands.cpp
+++ b/src/client/network/client_commands.cpp
@@ -112,7 +112,7 @@ void Client::onChunkData(sf::Packet& packet)
         chunk.blocks = decompressBlockData(compressed);
 
         // Add to chunk updates
-        m_chunks.updates.push_back(position);
+        m_chunks.updates.emplace(position);
     }
 }
 


### PR DESCRIPTION
The code being removed was suppose to build chunk meshes around the player, but it didn't really work so I thought I might have well remove this code, keeping the client update function a lot less bloated.

Also removes a few variable that I do not remember what they were for, and the game seems to still work perfectly fine without them, so why not