### PR TITLE
Refactor/simplify network host

### DIFF
--- a/src/common/common/network/net_host.cpp
+++ b/src/common/common/network/net_host.cpp
@@ -178,55 +178,29 @@ int NetworkHost::getMaxConnections() const
 void NetworkHost::sendToPeer(ENetPeer* peer, sf::Packet& packet, u8 channel, u32 flags)
 {
     ENetPacket* pkt = createPacket(packet, flags);
-    QueuedPacket qp;
-    qp.packet = pkt;
-    qp.peer = peer;
-    qp.style = QueuedPacket::Style::One;
-    qp.channel = channel;
-    m_queue.push_back(qp);
+    //  QueuedPacket qp;
+    // qp.packet = pkt;
+    // qp.peer = peer;
+    // qp.style = QueuedPacket::Style::One;
+    // qp.channel = channel;
+    // m_queue.push_back(qp);
+
+    enet_peer_send(peer, channel, pkt);
 }
 
 void NetworkHost::broadcastToPeers(sf::Packet& packet, u8 channel, u32 flags)
 {
     ENetPacket* pkt = createPacket(packet, flags);
-    QueuedPacket qp;
-    qp.packet = pkt;
-    qp.style = QueuedPacket::Style::Broadcast;
-    qp.channel = channel;
-    m_queue.push_back(qp);
+    // QueuedPacket qp;
+    // qp.packet = pkt;
+    /// qp.style = QueuedPacket::Style::Broadcast;
+    // qp.channel = channel;
+    enet_host_broadcast(mp_host, channel, pkt);
+    // m_queue.push_back(qp);
 }
 
 void NetworkHost::tick()
 {
-    // Send the queued packets, but not too many at once
-    const int MAX__SEND_LIMIT = 1024;
-
-    int bytesSent = 0;
-
-    while (!m_queue.empty()) {
-        auto qp = m_queue.front();
-        m_queue.pop_front();
-        bytesSent += qp.packet->dataLength;
-
-        switch (qp.style) {
-            case QueuedPacket::Style::Broadcast:
-                enet_host_broadcast(mp_host, qp.channel, qp.packet);
-                break;
-
-            case QueuedPacket::Style::One:
-                enet_peer_send(qp.peer, qp.channel, qp.packet);
-                break;
-
-            default:
-                break;
-        }
-
-        flush();
-        if (bytesSent > MAX__SEND_LIMIT) {
-            break;
-        }
-    }
-
     assert(mp_host);
     ENetEvent event;
     while (enet_host_service(mp_host, &event, 0) > 0) {

--- a/src/common/common/network/net_host.h
+++ b/src/common/common/network/net_host.h
@@ -12,17 +12,6 @@
 
 #include <SFML/System/Clock.hpp>
 
-struct QueuedPacket {
-    enum class Style {
-        One,
-        Broadcast,
-    };
-    ENetPeer* peer = nullptr;
-    ENetPacket* packet = nullptr;
-    Style style = Style::Broadcast;
-    u8 channel = 0;
-};
-
 /**
  * @brief Base class for network hosts (clients/ servers)
  */
@@ -100,7 +89,6 @@ class NetworkHost {
     void broadcastToPeers(sf::Packet& packet, u8 channel, u32 flags);
 
   private:
-    void removePeerFromPacketQueue(ENetPeer* peer);
     virtual void onPeerConnect(ENetPeer* peer) = 0;
     virtual void onPeerDisconnect(ENetPeer* peer) = 0;
     virtual void onPeerTimeout(ENetPeer* peer) = 0;
@@ -108,10 +96,6 @@ class NetworkHost {
                                   command_t command) = 0;
 
     void onCommandRecieve(ENetPeer* peer, const ENetPacket& packet);
-
-    void flush();
-
-    std::deque<QueuedPacket> m_queue;
 
     ENetHost* mp_host = nullptr;
     const std::string m_name;


### PR DESCRIPTION
For some reason I had a queue of packets in the network host class rather than sending them straight out.

I now know that enet basically stores a packet queue internally, and doesn't send them until you call the enet_host_service function.

This might solve #64 

Also after updating this, #148 is now redundant, as the chunk sorting code actually works now  (Before it didn't, as the chunks were send at a painfully slow speed) :)