### PR TITLE
Use operator[] over .at for accessing chunk's voxels 

### DIFF
--- a/src/client/world/chunk_mesh_generation.cpp
+++ b/src/client/world/chunk_mesh_generation.cpp
@@ -38,6 +38,8 @@ bool makeFace(const VoxelDataManager& voxelData, voxel_t thisId, voxel_t compare
 ChunkMeshCollection makeChunkMesh(const Chunk& chunk, const VoxelDataManager& voxelData)
 {
     sf::Clock clock;
+    static int count = 0;
+    static float totalTime = 0;
     ChunkMeshCollection meshes(chunk.getPosition());
 
     for (int y = 0; y < CHUNK_SIZE; y++) {
@@ -102,7 +104,9 @@ ChunkMeshCollection makeChunkMesh(const Chunk& chunk, const VoxelDataManager& vo
             }
         }
     }
-    // std::cout << clock.getElapsedTime().asMilliseconds() << std::endl;
-
+    //totalTime += clock.getElapsedTime().asSeconds() * 1000.0f;
+    //if (count++ % 100 == 0) {
+    //    std::cout << count << ' ' << totalTime << ' ' << totalTime / count << '\n';
+    //}
     return meshes;
 }

--- a/src/common/common/world/chunk.cpp
+++ b/src/common/common/world/chunk.cpp
@@ -1,7 +1,16 @@
 #include "chunk.h"
 #include "chunk_manager.h"
 
-// TODO Replace the .at with operator[] (when can be sure its safe to do so)
+namespace {
+// clang-format off
+    bool voxelPositionOutOfChunkBounds(const VoxelPosition& voxelPosition) {
+        return 
+        voxelPosition.x < 0 || voxelPosition.x >= CHUNK_SIZE ||
+        voxelPosition.y < 0 || voxelPosition.y >= CHUNK_SIZE ||
+        voxelPosition.z < 0 || voxelPosition.z >= CHUNK_SIZE;
+    }
+// clang-format on
+} // namespace
 
 Chunk::Chunk(ChunkManager& manager, const ChunkPosition& position)
     : mp_manager(manager)
@@ -19,29 +28,22 @@ void Chunk::qSetVoxel(const VoxelPosition& voxelPosition, voxel_t voxel)
     voxels.at(toLocalVoxelIndex(voxelPosition)) = voxel;
 }
 
-// clang-format off
 voxel_t Chunk::getVoxel(const VoxelPosition& voxelPosition) const
 {
-    if (voxelPosition.x < 0 || voxelPosition.x >= CHUNK_SIZE ||
-        voxelPosition.y < 0 || voxelPosition.y >= CHUNK_SIZE ||
-        voxelPosition.z < 0 || voxelPosition.z >= CHUNK_SIZE) {
-        return mp_manager.getVoxel(
-            toGlobalVoxelPosition(voxelPosition, m_position));
+    if (voxelPositionOutOfChunkBounds(voxelPosition)) {
+        return mp_manager.getVoxel(toGlobalVoxelPosition(voxelPosition, m_position));
     }
     return qGetVoxel(voxelPosition);
 }
 
 void Chunk::setVoxel(const VoxelPosition& voxelPosition, voxel_t voxel)
 {
-    if (voxelPosition.x < 0 || voxelPosition.x >= CHUNK_SIZE ||
-        voxelPosition.y < 0 || voxelPosition.y >= CHUNK_SIZE ||
-        voxelPosition.z < 0 || voxelPosition.z >= CHUNK_SIZE) {
-        return mp_manager.setVoxel(
-            toGlobalVoxelPosition(voxelPosition, m_position), voxel);
+    if (voxelPositionOutOfChunkBounds(voxelPosition)) {
+        return mp_manager.setVoxel(toGlobalVoxelPosition(voxelPosition, m_position),
+                                   voxel);
     }
     qSetVoxel(voxelPosition, voxel);
 }
-// clang-format on
 
 const ChunkPosition& Chunk::getPosition() const
 {

--- a/src/common/common/world/chunk.cpp
+++ b/src/common/common/world/chunk.cpp
@@ -20,12 +20,14 @@ Chunk::Chunk(ChunkManager& manager, const ChunkPosition& position)
 
 voxel_t Chunk::qGetVoxel(const VoxelPosition& voxelPosition) const
 {
-    return voxels.at(toLocalVoxelIndex(voxelPosition));
+    assert(voxelPositionOutOfChunkBounds(voxelPosition));
+    return voxels[toLocalVoxelIndex(voxelPosition)];
 }
 
 void Chunk::qSetVoxel(const VoxelPosition& voxelPosition, voxel_t voxel)
 {
-    voxels.at(toLocalVoxelIndex(voxelPosition)) = voxel;
+    assert(voxelPositionOutOfChunkBounds(voxelPosition));
+    voxels[toLocalVoxelIndex(voxelPosition)] = voxel;
 }
 
 voxel_t Chunk::getVoxel(const VoxelPosition& voxelPosition) const


### PR DESCRIPTION
During testing, this saves around about 0.3 to 0.5 milliseconds on average when building a chunk's mesh.

I whacked in an assert to keep some safekeeping for debug mode, to catch bugs etc early on