### PR TITLE
Added mouse invert and fixed leaves not rendering underwater 

### DIFF
--- a/config.obd
+++ b/config.obd
@@ -7,6 +7,9 @@ CLIENT_DATA
     window_width 1600
     window_height 900
 
+    vertical_sensitivity 1
+    horizontal_sensitivity 1
+    
     skin player
     texture_pack default
     shouldShowInstructions 1

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -83,6 +83,11 @@ bool Client::init(const ClientConfig& config, float aspect)
     mp_player = &m_entities[NetworkHost::getPeerId()];
     mp_player->position = {CHUNK_SIZE * 2, CHUNK_SIZE * 2 + 1, CHUNK_SIZE * 2};
 
+    m_mouseSensitivity = {
+        config.verticalSensitivity,
+        config.horizontalSensitivity
+    };
+
     m_rawPlayerSkin = gl::loadRawImageFile("skins/" + config.skinName);
     sendPlayerSkin(m_rawPlayerSkin);
 
@@ -104,8 +109,8 @@ void Client::handleInput(const sf::Window& window, const Keyboard& keyboard)
 
     if (!m_isMouseLocked && window.hasFocus() && sf::Mouse::getPosition(window).y >= 0) {
         auto change = sf::Mouse::getPosition(window) - lastMousePosition;
-        mp_player->rotation.x += static_cast<float>(change.y / 8.0f);
-        mp_player->rotation.y += static_cast<float>(change.x / 8.0f);
+        mp_player->rotation.x += static_cast<float>(change.y / 8.0f * m_mouseSensitivity.vertical);
+        mp_player->rotation.y += static_cast<float>(change.x / 8.0f * m_mouseSensitivity.horizontal);
         sf::Mouse::setPosition({(int)window.getSize().x / 2, (int)window.getSize().y / 2},
                                window);
 // This fixes mouse jittering on mac

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -56,6 +56,7 @@ class Client final : public NetworkHost {
 
     void update(float dt, float frameTime);
     void render(int width, int height);
+    void render();
     void endGame();
 
     EngineStatus currentStatus() const;
@@ -124,6 +125,11 @@ class Client final : public NetworkHost {
 
     VoxelPosition m_currentSelectedVoxelPos;
     bool m_voxelSelected = false;
+
+    struct {
+        float vertical;
+        float horizontal;
+    } m_mouseSensitivity;
 
     Entity* mp_player = nullptr;
     Entity m_externalCamera;

--- a/src/client/client_config.h
+++ b/src/client/client_config.h
@@ -16,6 +16,9 @@ struct ClientConfig {
     int fpsLimit = 60;
     int fov = 65;
 
+    float verticalSensitivity = 1.f;
+    float horizontalSensitivity = 1.f;
+
     bool isFpsCapped = true;
     bool shouldShowInstructions = true;
 

--- a/src/client/renderer/chunk_renderer.cpp
+++ b/src/client/renderer/chunk_renderer.cpp
@@ -139,6 +139,14 @@ ChunkRenderResult ChunkRenderer::renderChunks(const glm::vec3& cameraPosition,
     gl::loadUniform(m_solidShader.projectionViewLocation, projectionViewMatrix);
     ::renderChunks(solidDrawables, frustum, m_solidShader.chunkPositionLocation, result);
 
+    // Flora voxels
+    m_floraShader.program.bind();
+    gl::loadUniform(m_floraShader.projectionViewLocation, projectionViewMatrix);
+    gl::loadUniform(m_floraShader.timeLocation, time);
+    glDisable(GL_CULL_FACE);
+    ::renderChunks(floraDrawables, frustum, m_floraShader.chunkPositionLocation, result);
+    glEnable(GL_CULL_FACE);
+
     // Fluid voxels
     m_fluidShader.program.bind();
     gl::loadUniform(m_fluidShader.projectionViewLocation, projectionViewMatrix);
@@ -150,14 +158,6 @@ ChunkRenderResult ChunkRenderer::renderChunks(const glm::vec3& cameraPosition,
     ::renderChunks(fluidDrawables, frustum, m_fluidShader.chunkPositionLocation, result);
     glCheck(glCullFace(GL_BACK));
     glCheck(glDisable(GL_BLEND));
-
-    // Flora voxels
-    m_floraShader.program.bind();
-    gl::loadUniform(m_floraShader.projectionViewLocation, projectionViewMatrix);
-    gl::loadUniform(m_floraShader.timeLocation, time);
-    glDisable(GL_CULL_FACE);
-    ::renderChunks(floraDrawables, frustum, m_floraShader.chunkPositionLocation, result);
-    glEnable(GL_CULL_FACE);
 
     return result;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,10 @@ void loadFromConfigFile(Config& config)
     config.client.fpsLimit = std::stoi(clientData["fps_limit"]);
     config.client.fov = std::stoi(clientData["fov"]);
     config.client.fpsLimit = std::stoi(clientData["fps_limit"]);
+    config.client.verticalSensitivity = 
+        std::stof(clientData["vertical_sensitivity"]);
+    config.client.horizontalSensitivity = 
+        std::stof(clientData["horizontal_sensitivity"]);
     config.client.skinName = clientData["skin"];
     config.client.texturePack = clientData["texture_pack"];
     config.client.serverIp = clientData["server_ip"];


### PR DESCRIPTION
Added config option to have vertical and horizontal look invert as described in issue #154 . These options also allow sensitivity changes by using values less than or greater than 1 (or -1 for invert).

Fixed issue  #143 with leaves / plants not rendering under water.

Also added an overload method declaration for the client render method as I could not get the project to build without either adding this or removing the parameters from the current declaration.