### PR TITLE
GUI textbox API allows to limit which characters can be added to it 

### DIFF
--- a/src/client/gui/widget/text_box_widget.cpp
+++ b/src/client/gui/widget/text_box_widget.cpp
@@ -138,7 +138,6 @@ namespace gui {
     {
         if (m_isActive) {
             if (isCharacterValid(code) && isCharacterAuthorised(code) && m_textInput.length() < m_maxLength) {
-                std::cout << code << std::endl;
                 m_textInput.push_back(code);
                 m_displayText.push_back(m_inputHidden ? '*' : code);
                 mp_text->setText(m_displayText);

--- a/src/client/gui/widget/text_box_widget.cpp
+++ b/src/client/gui/widget/text_box_widget.cpp
@@ -118,10 +118,27 @@ namespace gui {
         }
     }
 
+    void TextBoxWidget::allowAllChars()
+    {
+        m_charsAuthorised = "";
+    }
+
+    void TextBoxWidget::limitChars(std::string charsAuthorised)
+    {
+        m_charsAuthorised = charsAuthorised;
+    }
+
+    bool TextBoxWidget::isCharacterAuthorised(unsigned char code)
+    {
+        return (m_charsAuthorised.find(code) != std::string::npos) ||
+                   (m_charsAuthorised == "");
+    }
+
     void TextBoxWidget::handleTextEntered(unsigned char code)
     {
         if (m_isActive) {
-            if (isCharacterValid(code) && m_textInput.length() < m_maxLength) {
+            if (isCharacterValid(code) && isCharacterAuthorised(code) && m_textInput.length() < m_maxLength) {
+                std::cout << code << std::endl;
                 m_textInput.push_back(code);
                 m_displayText.push_back(m_inputHidden ? '*' : code);
                 mp_text->setText(m_displayText);

--- a/src/client/gui/widget/text_box_widget.h
+++ b/src/client/gui/widget/text_box_widget.h
@@ -27,6 +27,8 @@ namespace gui {
 
         void handleClick(sf::Mouse::Button button, float mx, float my) final override;
         void handleMouseMove(float mx, float my) final override;
+        void allowAllChars(void);
+        void limitChars(std::string allowedChars);
         void handleTextEntered(unsigned char code) final override;
 
         void setOnClick(sol::function function);
@@ -38,6 +40,8 @@ namespace gui {
         void hideInputText();
 
       private:
+        bool isCharacterAuthorised(unsigned char code);
+
         TextComponent* mp_text = nullptr;
         RectangleComponent* mp_rectangle = nullptr;
         TextComponent* mp_label = nullptr;
@@ -45,6 +49,7 @@ namespace gui {
         bool m_isActive = false;
         std::string m_textInput;
         std::string m_displayText;
+        std::string m_charsAuthorised;
 
         std::string m_placeholder = "Enter something...";
         unsigned m_maxLength = 100;

--- a/src/client/lua/gui_widget_api.cpp
+++ b/src/client/lua/gui_widget_api.cpp
@@ -78,6 +78,8 @@ namespace {
         textboxApi["onMouseOff"] = sol::property(&gui::TextBoxWidget::setOnMouseOff);
 
         textboxApi["getText"] = &gui::TextBoxWidget::getText;
+        textboxApi["limitChars"] = &gui::TextBoxWidget::limitChars;
+        textboxApi["allowAllChars"] = &gui::TextBoxWidget::allowAllChars;
         textboxApi["hideInput"] = &gui::TextBoxWidget::hideInputText;
         textboxApi["placeholder"] = sol::property(&gui::TextBoxWidget::setPlaceholder);
         textboxApi["maxLength"] = sol::property(&gui::TextBoxWidget::setMaxLength);


### PR DESCRIPTION
This addresses #180 .
I have added to the Lua API `textBox:limitChars("123456789")` (which in this case would only allow digits from 1 to 9 to be entered) as well as `textBox:allowAllChars()` (which resets the chars that had been previously prevented).
I store the authorised chars in `std::string m_charsAuthorised` and, this may not be a good design choice, if the field is an empty string it considers all chars to be authorised. Thus, `textBox:allowAllChars()` is basically calling `textBox:limitChars("")` .
Tell me what you think.