### PR TITLE
Render Distance

### DIFF
--- a/config.obd
+++ b/config.obd
@@ -2,6 +2,7 @@ CLIENT_DATA
     cap_fps 0
     fps_limit 60
     fov 90
+    renderDistance 50.f
 
     fullscreen 0
     window_width 1600

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -77,6 +77,8 @@ bool Client::init(const ClientConfig& config, float aspect)
     mp_player = &m_entities[NetworkHost::getPeerId()];
     mp_player->position = {CHUNK_SIZE * 2, CHUNK_SIZE * 2 + 1, CHUNK_SIZE * 2};
 
+    m_renderDistance = config.renderDistance;
+
     m_mouseSensitivity = {config.verticalSensitivity, config.horizontalSensitivity};
 
     m_rawPlayerSkin = gl::loadRawImageFile("skins/" + config.skinName);
@@ -347,7 +349,8 @@ void Client::render()
         m_chunks.manager.getVoxel(toVoxelPosition(mp_player->position)) ==
         m_voxelData.getVoxelId(CommonVoxel::Water);
     auto result = m_chunkRenderer.renderChunks(mp_player->position, m_frustum,
-                                               playerProjectionView, isPlayerInWater);
+                                               playerProjectionView, isPlayerInWater, 
+                                               m_renderDistance);
 
     // Render selection box
     if (m_voxelSelected) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -131,4 +131,6 @@ class Client final : public NetworkHost {
 
     unsigned m_noMeshingCount = 0;
     bool m_voxelMeshing = false;
+
+    float m_renderDistance;
 };

--- a/src/client/client_config.h
+++ b/src/client/client_config.h
@@ -15,6 +15,7 @@ struct ClientConfig {
     int windowHeight = 720;
     int fpsLimit = 60;
     int fov = 65;
+    float renderDistance = 50.f;
 
     float verticalSensitivity = 1.f;
     float horizontalSensitivity = 1.f;

--- a/src/client/renderer/chunk_renderer.h
+++ b/src/client/renderer/chunk_renderer.h
@@ -85,7 +85,7 @@ class ChunkRenderer final {
                                    const ViewFrustum& frustum,
                                    const glm::mat4& projectionViewMatrix,
                                    bool cameraInWater, 
-                                   float renderDistance = 10.f);
+                                   float renderDistance);
 
     // Used for the debug stat view
     int getTotalChunks() const;

--- a/src/client/renderer/chunk_renderer.h
+++ b/src/client/renderer/chunk_renderer.h
@@ -84,7 +84,8 @@ class ChunkRenderer final {
     ChunkRenderResult renderChunks(const glm::vec3& cameraPosition,
                                    const ViewFrustum& frustum,
                                    const glm::mat4& projectionViewMatrix,
-                                   bool cameraInWater);
+                                   bool cameraInWater, 
+                                   float renderDistance = 10.f);
 
     // Used for the debug stat view
     int getTotalChunks() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@ namespace {
             std::stoi(clientData["shouldShowInstructions"]);
         config.client.fpsLimit = std::stoi(clientData["fps_limit"]);
         config.client.fov = std::stoi(clientData["fov"]);
+        config.client.renderDistance = std::stoi(clientData["renderDistance"]);
         config.client.fpsLimit = std::stoi(clientData["fps_limit"]);
         config.client.verticalSensitivity = std::stof(clientData["vertical_sensitivity"]);
         config.client.horizontalSensitivity =


### PR DESCRIPTION
This addresses issue #146.
I have not implemented fog, only render distance (using Manhattan distance).
By default the render distance is set to 5 chunks away.

## Implementation

In chunk_renderer.cpp, the runderChunks method now goes through unrendered chunks and render them if in range at each tick and then goes through all rendered chunks and unrenders those not in range anymore (this means at each tick the client has to loop through all rendered chunks, hopefully that's not impacting performance). Render distance is set by default in chunk_renderer.h but should prob be added in the config files (was not entirely sure the best way to go about this, don't hesitate to let me know and I'll make further commits).
I'm new to OpenGl and will look into good ways to create a fog effect.