### PR TITLE
Unknown keys error screen popup #184

### DIFF
--- a/src/client/input/keyboard.cpp
+++ b/src/client/input/keyboard.cpp
@@ -10,11 +10,13 @@ void Keyboard::update(sf::Event e)
     m_recentlyReleased = sf::Keyboard::KeyCount;
     switch (e.type) {
         case sf::Event::KeyReleased:
+            if (e.key.code == -1) return;
             m_recentlyReleased = e.key.code;
             m_keys[e.key.code] = false;
             break;
 
         case sf::Event::KeyPressed:
+            if (e.key.code == -1) return;
             m_keys[e.key.code] = true;
             break;
 


### PR DESCRIPTION
This addresses issue #184 

Simply adding an if statement to check the event key code, and do nothing (return) if it is -1.

I assumed that any unknown/undefined keys would lead to a keycode of -1, and thus this quick fix should catch them all. 