### PR TITLE
include <stdexcept> header

### DIFF
--- a/src/client/gl/framebuffer.cpp
+++ b/src/client/gl/framebuffer.cpp
@@ -2,6 +2,7 @@
 
 #include "gl_errors.h"
 #include <utility>
+#include <stdexcept>
 
 namespace gl {
     Framebuffer::Framebuffer()


### PR DESCRIPTION
'runtime_error' is not a member of 'std'